### PR TITLE
Fix Python cert issues

### DIFF
--- a/python/Dockerfile.osp
+++ b/python/Dockerfile.osp
@@ -76,9 +76,11 @@ RUN --mount=type=secret,id=wolfssl_password \
 	\
 	# Compile and install wolfSSL
 	cd /usr/src/wolfssl; \
+    sed -i '/^#ifdef WOLFSSL_PYTHON/,/^#endif/d' wolfssl/wolfcrypt/settings.h; \
 	# NO_INT128 required due to type conflict with bluetooth.h
 	./configure --enable-opensslall --enable-tls13 --enable-tlsx --enable-crl \
 		--enable-postauth --enable-certext --enable-certgen --enable-sessioncerts \
+        --enable-altcertchains \
 		CFLAGS="-DHAVE_EX_DATA -DWOLFSSL_ERROR_CODE_OPENSSL -DHAVE_SECRET_CALLBACK -DWOLFSSL_PYTHON \
 		-DWOLFSSL_ALT_NAMES -DWOLFSSL_SIGNER_DER_CERT -DKEEP_PEER_CERT -DNO_INT128" --prefix=/usr \
 		--enable-fips=v5; \

--- a/python/Dockerfile.osp
+++ b/python/Dockerfile.osp
@@ -76,6 +76,7 @@ RUN --mount=type=secret,id=wolfssl_password \
 	\
 	# Compile and install wolfSSL
 	cd /usr/src/wolfssl; \
+    # Prevent wolfSSL from enabling WOLFSSL_OLD_OID_SUM (no longer needed)
     sed -i '/^#ifdef WOLFSSL_PYTHON/,/^#endif/d' wolfssl/wolfcrypt/settings.h; \
 	# NO_INT128 required due to type conflict with bluetooth.h
 	./configure --enable-opensslall --enable-tls13 --enable-tlsx --enable-crl \


### PR DESCRIPTION
- Disables `WOLFSSL_OLD_OID_SUM` which was previously enabled to make the CPython tests pass because they were making wrong assumptions about OIDs. It's best to fix the tests themselves (in wolfSSL/osp) instead. Having this enabled caused issues in cert parsing due to OID sum collisions.
- Adds `--enable-altcertchains`