### PR TITLE
Improvements to OpenJDK Base Image

### DIFF
--- a/java/wolfssl-openjdk-fips-root/Dockerfile
+++ b/java/wolfssl-openjdk-fips-root/Dockerfile
@@ -75,12 +75,14 @@ RUN --mount=type=secret,id=wolfssl_pw \
 # We run the wolfCrypt test app to verify native crypto is working after
 # library build.
 # Disabling MD5 since is not a FIPS validated algorithm in cert 4718.
+# Manually adding HAVE_CTS to CFLAGS to enable AES-CTS. wolfSSL versions
+# > 5.8.2 will automatically have this enabled with --enable-jni.
 WORKDIR /build/wolfssl
 RUN ./configure \
         --enable-fips=v5 \
         --enable-jni \
         --disable-md5 \
-        --prefix=/usr/local \
+        --prefix=/usr/local CFLAGS="-DHAVE_CTS" \
     && make -j$(nproc) \
     && echo "Updating FIPS in-core integrity check hash..." \
     && ./fips-hash.sh \
@@ -218,12 +220,13 @@ COPY --from=wolfjsse-builder /build/artifacts/jar/wolfssl-jsse.jar /usr/share/ja
 # Copy and compile Java source files
 COPY src/main/FipsInitCheck.java /build/src/main/
 COPY src/providers/*.java /build/src/providers/
+COPY src/META-INF /build/META-INF
 
 # Compile main application and filtered providers
 RUN mkdir -p /build/classes \
     && javac -cp "/usr/share/java/*" -d /build/classes /build/src/main/FipsInitCheck.java \
     && javac -cp "/usr/share/java/*" -d /build/classes /build/src/providers/*.java \
-    && jar cvf /build/filtered-providers.jar -C /build/classes com
+    && jar cvf /build/filtered-providers.jar -C /build/classes com -C /build META-INF
 
 # ------------------------------------------------------------------------------
 # Stage 6: Runtime Image
@@ -307,6 +310,13 @@ ENV WOLFJCE_DEBUG=false
 ENV WOLFJSSE_DEBUG=false
 ENV WOLFJSSE_ENGINE_DEBUG=false
 ENV FIPS_CHECK=true
+
+# Set CLASSPATH to include provider JARs for ServiceLoader compatibility
+# ServiceLoader only scans the application classpath, not bootclasspath
+# NOTE: The entrypoint script (docker-entrypoint.sh) will automatically
+# append these JARs to any user-provided CLASSPATH to ensure ServiceLoader
+# support even when users set custom classpaths
+ENV CLASSPATH="/usr/share/java/wolfcrypt-jni.jar:/usr/share/java/wolfssl-jsse.jar:/usr/share/java/filtered-providers.jar"
 
 # JVM flags for the filtered providerw which wrap Sun providers for non-crypto
 # services. These flags are required because FilteredSun* providers use

--- a/java/wolfssl-openjdk-fips-root/Dockerfile
+++ b/java/wolfssl-openjdk-fips-root/Dockerfile
@@ -77,12 +77,14 @@ RUN --mount=type=secret,id=wolfssl_pw \
 # Disabling MD5 since is not a FIPS validated algorithm in cert 4718.
 # Manually adding HAVE_CTS to CFLAGS to enable AES-CTS. wolfSSL versions
 # > 5.8.2 will automatically have this enabled with --enable-jni.
+# Manually adding WOLFSSL_PUBLIC_MP for RSA KeyFactory support. <= 5.8.2
+# did not add this into --enable-jni yet.
 WORKDIR /build/wolfssl
 RUN ./configure \
         --enable-fips=v5 \
         --enable-jni \
         --disable-md5 \
-        --prefix=/usr/local CFLAGS="-DHAVE_CTS" \
+        --prefix=/usr/local CFLAGS="-DHAVE_CTS -DWOLFSSL_PUBLIC_MP" \
     && make -j$(nproc) \
     && echo "Updating FIPS in-core integrity check hash..." \
     && ./fips-hash.sh \

--- a/java/wolfssl-openjdk-fips-root/Dockerfile
+++ b/java/wolfssl-openjdk-fips-root/Dockerfile
@@ -287,6 +287,13 @@ RUN cp $JAVA_HOME/conf/security/java.security $JAVA_HOME/conf/security/java.secu
 COPY java.security $JAVA_HOME/conf/security/java.security
 RUN chmod 644 $JAVA_HOME/conf/security/java.security
 
+# Copy FIPS 140-3 compliant Kerberos configuration.
+# This restricts Kerberos to use only AES encryption types (aes256-cts,
+# aes128-cts) which are supported by wolfCrypt FIPS Certificate #4718.
+# DES, 3DES, and RC4 are excluded as they are not within the FIPS boundary.
+COPY krb5.conf /etc/krb5.conf
+RUN chmod 644 /etc/krb5.conf
+
 # Copy scripts and set permissions
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 COPY scripts/integrity-check.sh /usr/local/bin/integrity-check.sh

--- a/java/wolfssl-openjdk-fips-root/README.md
+++ b/java/wolfssl-openjdk-fips-root/README.md
@@ -216,6 +216,7 @@ docker run -v /path/to/your/app:/app \
 |----------|-------------|---------|
 | `JAVA_OPTS` | JVM configuration options | `-Xmx512m` |
 | `JAVA_TOOL_OPTIONS` | JVM module access flags for filtered providers | See Dockerfile |
+| `CLASSPATH` | Application classpath including provider JARs (for ServiceLoader) | `/usr/share/java/*.jar` |
 | `WOLFJCE_DEBUG` | Enable wolfJCE debug logging | `false` |
 | `WOLFJSSE_DEBUG` | Enable wolfJSSE debug logging | `false` |
 | `WOLFJSSE_ENGINE_DEBUG` | Enable wolfJSSE SSLEngine debug logging | `false` |
@@ -322,6 +323,77 @@ inherit these restrictions.
 **Note:** Applications that override the system krb5.conf with their own
 configuration should ensure they only permit AES-based encryption types to
 maintain FIPS compliance.
+
+### Provider Discovery and ServiceLoader
+
+The wolfSSL security providers (wolfJCE, wolfJSSE, and filtered Sun providers)
+are configured to be discoverable through both Java's Security framework and
+the ServiceLoader mechanism. This dual-path approach ensures maximum
+compatibility with Java applications and frameworks.
+
+**Dual Classpath Configuration:**
+
+Provider JAR files are available on both the boot classpath and application
+classpath:
+
+- **Boot Classpath** (`-Xbootclasspath/a` via `JAVA_TOOL_OPTIONS`):
+  - Required for early provider registration in the Security framework
+  - Ensures providers are available before application code loads
+  - Used by the `java.security` configuration file
+
+- **Application Classpath** (`CLASSPATH` environment variable):
+  - Required for ServiceLoader to discover providers
+  - Enables `ServiceLoader.load(Provider.class)` to find providers
+  - Allows frameworks (Spring Boot, etc.) to discover providers
+  - Set by default to: `/usr/share/java/wolfcrypt-jni.jar:/usr/share/java/wolfssl-jsse.jar:/usr/share/java/filtered-providers.jar`
+
+**ServiceLoader Support:**
+
+All providers include `META-INF/services/java.security.Provider` files for
+ServiceLoader discovery:
+- `com.wolfssl.provider.jce.WolfCryptProvider`
+- `com.wolfssl.provider.jsse.WolfSSLProvider`
+- `com.wolfssl.security.providers.FilteredSun`
+- `com.wolfssl.security.providers.FilteredSunRsaSign`
+- `com.wolfssl.security.providers.FilteredSunEC`
+
+**Important Notes for Application Developers:**
+
+The container's entrypoint script automatically ensures provider JARs are
+included in the `CLASSPATH`, even if you set a custom classpath. This means:
+
+**You can set custom CLASSPATH values without breaking ServiceLoader:**
+
+```bash
+# Example 1: Using docker run with custom CLASSPATH
+docker run -e CLASSPATH=/app/myapp.jar wolfssl-openjdk-fips-root:latest java MyApp
+
+# Example 2: Using -cp flag (note: this overrides CLASSPATH environment variable)
+docker run wolfssl-openjdk-fips-root:latest java -cp /app/myapp.jar MyApp
+```
+
+In both cases, the entrypoint script detects your custom classpath and
+automatically appends the provider JARs to ensure ServiceLoader compatibility.
+
+**Exception - Direct java -cp usage:**
+If you use `java -cp` directly (not through the container entrypoint), you must
+manually include the provider JARs:
+
+```bash
+# When bypassing the entrypoint
+java -cp /app/myapp.jar:/usr/share/java/wolfcrypt-jni.jar:/usr/share/java/wolfssl-jsse.jar:/usr/share/java/filtered-providers.jar \
+     com.example.MyApplication
+```
+
+**How it works:**
+The entrypoint script (in `docker-entrypoint.sh`) checks the `CLASSPATH`
+environment variable at container startup:
+1. If `CLASSPATH` is not set, it sets it to provider JARs only
+2. If `CLASSPATH` is set but missing provider JARs, it appends provider JARs
+3. If `CLASSPATH` already contains provider JARs, no change
+
+This ensures providers are always discoverable via ServiceLoader regardless of
+how users configure their applications.
 
 ### WolfSSLKeyStore (WKS) Format
 

--- a/java/wolfssl-openjdk-fips-root/README.md
+++ b/java/wolfssl-openjdk-fips-root/README.md
@@ -46,6 +46,7 @@ wolfssl-openjdk-fips-root/
 ├── docker-entrypoint.sh            # Container entry point script
 ├── java.security                   # FIPS Java security configuration
 ├── java.security.original          # Original Java security configuration
+├── krb5.conf                       # FIPS Kerberos configuration (AES only)
 ├── scripts/                        # Utility scripts
 │   └── integrity-check.sh          # Library integrity verification script
 └── src/
@@ -63,6 +64,8 @@ When built, the container organizes files as follows:
 
 ```
 /
+├── etc/
+│   └── krb5.conf                   # FIPS Kerberos configuration
 ├── usr/
 │   ├── lib/
 │   │   └── jni/                    # JNI libraries
@@ -291,6 +294,34 @@ them from java.security.
 5. Set JVM module access flags for filtered provider reflection
 6. Convert system cacerts from JKS to WKS format for FIPS compliance
 7. Set default KeyStore type to WKS for FIPS compliance
+8. Configure Kerberos (krb5) to use only FIPS-compliant encryption types
+
+### Kerberos Configuration
+
+The container includes a FIPS-compliant Kerberos configuration file
+(`/etc/krb5.conf`) that restricts Kerberos to use only AES-based encryption
+types. This is necessary because the default Java Kerberos implementation
+attempts to generate keys for all encryption types including DES, 3DES, and
+RC4, which are not within the wolfCrypt FIPS boundary.
+
+**Permitted Encryption Types:**
+- `aes256-cts-hmac-sha1-96` (etype 18)
+- `aes128-cts-hmac-sha1-96` (etype 17)
+
+**Disabled Encryption Types:**
+- DES-CBC-CRC (etype 1)
+- DES-CBC-MD5 (etype 3)
+- DES3-CBC-SHA1 (etype 16)
+- RC4-HMAC (etype 23)
+- All other non-AES encryption types
+
+The configuration also sets `allow_weak_crypto = false` to prevent fallback
+to weak encryption algorithms. Applications using Kerberos will automatically
+inherit these restrictions.
+
+**Note:** Applications that override the system krb5.conf with their own
+configuration should ensure they only permit AES-based encryption types to
+maintain FIPS compliance.
 
 ### WolfSSLKeyStore (WKS) Format
 

--- a/java/wolfssl-openjdk-fips-root/docker-entrypoint.sh
+++ b/java/wolfssl-openjdk-fips-root/docker-entrypoint.sh
@@ -56,6 +56,25 @@ if [ -n "$USER_JAVA_OPTS" ]; then
     JAVA_OPTS="$JAVA_OPTS $USER_JAVA_OPTS"
 fi
 
+# Ensure provider JARs are always on CLASSPATH for ServiceLoader support
+# This handles cases where users set a custom CLASSPATH but forget to include
+# the provider JARs
+PROVIDER_JARS="/usr/share/java/wolfcrypt-jni.jar:/usr/share/java/wolfssl-jsse.jar:/usr/share/java/filtered-providers.jar"
+
+if [ -z "$CLASSPATH" ]; then
+    # CLASSPATH not set, use only provider JARs
+    export CLASSPATH="$PROVIDER_JARS"
+else
+    # CLASSPATH is set, check if it already contains our provider JARs
+    if [[ ! "$CLASSPATH" =~ "wolfcrypt-jni.jar" ]] || \
+       [[ ! "$CLASSPATH" =~ "wolfssl-jsse.jar" ]] || \
+       [[ ! "$CLASSPATH" =~ "filtered-providers.jar" ]]; then
+        # Provider JARs not found, append them
+        echo "Note: User CLASSPATH detected, appending wolfSSL provider JARs for ServiceLoader support"
+        export CLASSPATH="${CLASSPATH}:${PROVIDER_JARS}"
+    fi
+fi
+
 export LD_LIBRARY_PATH=/usr/lib/jni:/usr/local/lib:$LD_LIBRARY_PATH
 export JAVA_LIBRARY_PATH=/usr/lib/jni:/usr/local/lib
 

--- a/java/wolfssl-openjdk-fips-root/java.security
+++ b/java/wolfssl-openjdk-fips-root/java.security
@@ -168,7 +168,7 @@ security.provider.10=JdkSASL
 # entries.
 #
 # FIPS: Prefer wolfJCE DRBG for SecureRandom.getInstanceStrong()
-securerandom.strongAlgorithms=HashDRBG:wolfJCE
+securerandom.strongAlgorithms=HashDRBG:wolfJCE,Hash_DRBG:wolfJCE,DRBG:wolfJCE
 
 #
 # Sun provider DRBG configuration and default instantiation request.

--- a/java/wolfssl-openjdk-fips-root/krb5.conf
+++ b/java/wolfssl-openjdk-fips-root/krb5.conf
@@ -1,0 +1,33 @@
+#
+# FIPS 140-3 Compliant Kerberos Configuration
+#
+# This configuration file restricts Kerberos to use only AES-based
+# encryption types, which are supported by wolfCrypt FIPS Certificate #4718.
+#
+# DES, 3DES, and RC4 encryption types are excluded as they are not
+# within the wolfCrypt FIPS boundary.
+#
+
+[libdefaults]
+    # FIPS-compliant encryption types (AES only)
+    # These are the only encryption types that will be used for:
+    # - Ticket-granting tickets (TGT)
+    # - Service tickets
+    # - Key generation and storage
+    default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
+    default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
+    permitted_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
+
+    # Disable weak cryptography to prevent fallback to DES/3DES/RC4
+    allow_weak_crypto = false
+
+    # Default realm (can be overridden by applications)
+    # default_realm = EXAMPLE.COM
+
+[realms]
+    # KDC realm configurations go here
+    # Applications can override this via their own krb5.conf
+
+[domain_realm]
+    # Domain to realm mappings go here
+    # Applications can override this via their own krb5.conf

--- a/java/wolfssl-openjdk-fips-root/src/META-INF/services/java.security.Provider
+++ b/java/wolfssl-openjdk-fips-root/src/META-INF/services/java.security.Provider
@@ -1,0 +1,3 @@
+com.wolfssl.security.providers.FilteredSun
+com.wolfssl.security.providers.FilteredSunRsaSign
+com.wolfssl.security.providers.FilteredSunEC

--- a/java/wolfssl-openjdk-fips-root/src/main/FipsInitCheck.java
+++ b/java/wolfssl-openjdk-fips-root/src/main/FipsInitCheck.java
@@ -745,7 +745,7 @@ public class FipsInitCheck {
         /* JCE service types that should use wolfJCE */
         String[] jceServiceTypes = {
             "MessageDigest", "Mac", "Cipher", "Signature", "KeyGenerator",
-            "KeyPairGenerator", "KeyAgreement",
+            "KeyPairGenerator", "KeyAgreement", "SecretKeyFactory",
             "AlgorithmParameterGenerator", "SecureRandom"
         };
 

--- a/java/wolfssl-openjdk-fips-root/src/providers/FilteredSun.java
+++ b/java/wolfssl-openjdk-fips-root/src/providers/FilteredSun.java
@@ -46,7 +46,10 @@ public class FilteredSun extends Provider {
 
     public FilteredSun() {
 
-        super("FilteredSun", 1.0, "Filtered SUN for non-crypto ops");
+        super("FilteredSun",
+            Double.parseDouble(
+                System.getProperty("java.specification.version")),
+            "Filtered SUN for non-crypto ops");
 
         try {
             System.err.println("Loading original SUN...");

--- a/java/wolfssl-openjdk-fips-root/src/providers/FilteredSunEC.java
+++ b/java/wolfssl-openjdk-fips-root/src/providers/FilteredSunEC.java
@@ -45,7 +45,10 @@ public class FilteredSunEC extends Provider {
 
     public FilteredSunEC() {
 
-        super("FilteredSunEC", 1.0, "Filtered SunEC for non-crypto ops");
+        super("FilteredSunEC",
+            Double.parseDouble(
+                System.getProperty("java.specification.version")),
+            "Filtered SunEC for non-crypto ops");
 
         try {
             System.err.println("Loading original SunEC...");

--- a/java/wolfssl-openjdk-fips-root/src/providers/FilteredSunRsaSign.java
+++ b/java/wolfssl-openjdk-fips-root/src/providers/FilteredSunRsaSign.java
@@ -43,7 +43,9 @@ public class FilteredSunRsaSign extends Provider {
 
     public FilteredSunRsaSign() {
 
-        super("FilteredSunRsaSign", 1.0,
+        super("FilteredSunRsaSign",
+            Double.parseDouble(
+                System.getProperty("java.specification.version")),
             "Filtered SunRsaSign for non-crypto ops");
 
         try {

--- a/java/wolfssl-openjdk-fips-root/test-images/basic-test-image/Dockerfile
+++ b/java/wolfssl-openjdk-fips-root/test-images/basic-test-image/Dockerfile
@@ -21,10 +21,14 @@ RUN javac -cp "/opt/wolfssl-fips/bin:/usr/share/java/*" \
 # Set the working directory back to /app
 WORKDIR /app
 
+# Add test application classes to CLASSPATH
+# Base image already includes provider JARs in CLASSPATH, so we just prepend our app directory
+ENV CLASSPATH="/app/test:${CLASSPATH}"
+
 # Default command runs the comprehensive FIPS test suite
 # Users can override this to run individual test classes
-CMD ["java", "-cp", "/app/test:/opt/wolfssl-fips/bin:/usr/share/java/*", "FipsUserApplication"]
+CMD ["java", "FipsUserApplication"]
 
 # Alternative commands for running specific test suites:
-# docker run wolfssl-fips-basic-test-image:latest java -cp "/app/test:/opt/wolfssl-fips/bin:/usr/share/java/*" CryptoTestSuite
-# docker run wolfssl-fips-basic-test-image:latest java -cp "/app/test:/opt/wolfssl-fips/bin:/usr/share/java/*" TlsTestSuite
+# docker run wolfssl-fips-basic-test-image:latest java CryptoTestSuite
+# docker run wolfssl-fips-basic-test-image:latest java TlsTestSuite

--- a/java/wolfssl-openjdk-fips-root/test-images/basic-test-image/README.md
+++ b/java/wolfssl-openjdk-fips-root/test-images/basic-test-image/README.md
@@ -96,13 +96,13 @@ docker run --rm wolfssl-fips-basic-test-image:latest
 **JCA Cryptographic Operations Only:**
 ```bash
 docker run --rm wolfssl-fips-basic-test-image:latest \
-  java -cp "/app/test:/opt/wolfssl-fips/bin:/usr/share/java/*" CryptoTestSuite
+  java CryptoTestSuite
 ```
 
 **SSL/TLS Operations Only:**
 ```bash
 docker run --rm wolfssl-fips-basic-test-image:latest \
-  java -cp "/app/test:/opt/wolfssl-fips/bin:/usr/share/java/*" TlsTestSuite
+  java TlsTestSuite
 ```
 
 ## Environment Variables


### PR DESCRIPTION
This PR includes miscellaneous improvements and fixes to the Java OpenJDK root.io base image and test-image that goes with it.  Changes/improvements include:

- Add `SecretKeyFactory` to `FipsInitCheck`, now that wolfJCE implements `SecretKeyFactory`
- Add more aliases in `java.security` for `securerandom.strongAlgorithms` - now includes `HashDRBG:wolfJCE,Hash_DRBG:wolfJCE,DRBG:wolfJCE`
- Add customized `krb5.conf` for FIPS-compliant krb5 usage from Java
- Define `HAVE_CTS` when building native wolfSSL to use the OpenSSL compatibility layer AES-CTS implementation (still FIPS compliant since it uses FIPS-validated components internally). wolfSSL versions > 5.8.2 will automatically define this when `--enable-jni` is used.
- Fix `ServiceProvider` registration of security providers
- Fix the versioning for filtered security providers. They should broadcast their version matching the Java version used.
- Simplify `test-image/basic-test-image` to use `CLASSPATH` instead of `-cp`