### PR TITLE
Allow MD5 in Java container

### DIFF
--- a/java/wolfssl-openjdk-fips-root/src/main/FipsInitCheck.java
+++ b/java/wolfssl-openjdk-fips-root/src/main/FipsInitCheck.java
@@ -399,7 +399,7 @@ public class FipsInitCheck {
      *
      * This also spot checks algorithms that should not be available in
      * a FIPS validated wolfCrypt are also not available via Java
-     * services (ex: MessageDigest.MD5).
+     * services (ex: Mac.HmacMD5).
      *
      * @throws SecurityException if any algorithm fails to instantiate with
      *         the expected wolfSSL provider.
@@ -418,7 +418,12 @@ public class FipsInitCheck {
             "SHA-1", "SHA-224", "SHA-256", "SHA-384", "SHA-512",
             "SHA3-224", "SHA3-256", "SHA3-384", "SHA3-512"
         };
-        String[] nonFipsDigests = { "MD5" };
+        /* MD5 is a non-FIPS digest, but wolfCrypt enables it when enabling JNI,
+         * and wolfCrypt FIPS doesn't disallow it (see wolfSSL PR #5159:
+         * https://github.com/wolfSSL/wolfssl/pull/5159), as long as it doesn't
+         * enter the FIPS boundary. This also applies to MD5withRSA.
+         */
+        String[] nonFipsDigests = {};
 
         /* Mac - FIPS and non-FIPS validated algorithms */
         String[] fipsApprovedMacs = {
@@ -470,9 +475,7 @@ public class FipsInitCheck {
             "SHA384withRSA/PSS",
             "SHA512withRSA/PSS"
         };
-        String[] nonFipsSignatures = {
-            "MD5withRSA"
-        };
+        String[] nonFipsSignatures = {};
 
         /* SSLContext protocols */
         String[] sslContexts = {

--- a/java/wolfssl-openjdk-fips-root/src/main/FipsInitCheck.java
+++ b/java/wolfssl-openjdk-fips-root/src/main/FipsInitCheck.java
@@ -399,7 +399,7 @@ public class FipsInitCheck {
      *
      * This also spot checks algorithms that should not be available in
      * a FIPS validated wolfCrypt are also not available via Java
-     * services (ex: Mac.HmacMD5).
+     * services (ex: Mac.getInstance("HmacMD5")).
      *
      * @throws SecurityException if any algorithm fails to instantiate with
      *         the expected wolfSSL provider.


### PR DESCRIPTION
MD5 is allowed by FIPS wolfCrypt, as long as it stays outside of the FIPS boundary (see https://github.com/wolfSSL/wolfssl/pull/5159).

wolfcrypt-jni follows suit (see https://github.com/wolfSSL/wolfcrypt-jni/blob/master/jni/jni_feature_detect.c#L31 where it is not disabled with FIPS, compare it to line 337, where HmacMD5 is explicitly disabled with FIPS).

This container builds wolfCrypt with `--enable-jni --disable-md5`, but `--disable-md5` takes no effect because JNI forces MD5 to be on (see https://github.com/wolfSSL/wolfssl/blob/master/configure.ac#L7980). I'll try to fix this tomorrow, but past releases will remain like that, so the container needs to take it into consideration.

After #9, the container start up fails because MD5 is not really disabled. I discussed it with Chris and we concluded that we can allow MD5 in the container, making it clear that it's not in the boundary.