### PR TITLE
Update wolfssl-openjdk-fips-root container with updated FIPS release and filtered providers

### DIFF
--- a/java/wolfssl-openjdk-fips-root/Dockerfile
+++ b/java/wolfssl-openjdk-fips-root/Dockerfile
@@ -63,7 +63,8 @@ FROM builder AS wolfssl-builder
 # This bundle name can change depending on wolfCrypt FIPS OE
 RUN --mount=type=secret,id=wolfssl_pw \
     PW="$(cat /run/secrets/wolfssl_pw)" \
-    && curl -fLso /tmp/wolfssl-commercial.7z "https://www.wolfssl.com/comm/wolfssl/wolfssl-5.8.4-commercial-fips-v5.2.3.7z" \
+    && curl -fLso /tmp/wolfssl-commercial.7z "https://www.wolfssl.com/comm/wolfssl/wolfssl-5.9.1-commercial-fips-v5.2.3.7z" \
+    && echo "13280504dbfea0cb891404ef9ad4f2ee3ab02e0a327c80f93bc1f546224ef8db  /tmp/wolfssl-commercial.7z" | sha256sum -c - \
     && 7z x /tmp/wolfssl-commercial.7z -p"$PW" -o/build \
     && rm -f /tmp/wolfssl-commercial.7z \
     && ls -la /build/ \

--- a/java/wolfssl-openjdk-fips-root/README.md
+++ b/java/wolfssl-openjdk-fips-root/README.md
@@ -110,14 +110,11 @@ The following list includes the services that are left exposed/available:
 
 **SunEC** (FilteredSunEC.java):
 - AlgorithmParameters (EC)
-- KeyFactory (EC)
 
 **SunRsaSign** (FilteredSunRsaSign.java):
-- KeyFactory (RSA)
 - KeyFactory (RSASSA-PSS)
 
 **SUN** (FilteredSun.java):
-- CertPathBuilder (PKIX)
 - CertStore (Collection)
 - CertStore (com.sun.security.IndexedCollection)
 - CertificateFactory (X.509)
@@ -524,13 +521,12 @@ docker run -e WOLFJCE_DEBUG=true \
 
 **ASN parsing error, invalid input (-140)** - This error has been observed
 when testing connections to `www.github.com:443`. This is an ASN decoding
-issue that exists in the wolfSSL 5.8.0 release, but is fixed in the 5.8.2
-release. There is not yet a FIPS 140-3 v5.2.3 release for wolfSSL 5.8.2, but
-will be soon.
+issue that affected wolfSSL 5.8.0 and was fixed in wolfSSL 5.8.2. Current
+builds of this container use wolfSSL 5.9.1 and are not affected.
 
 ## Version Information
 
-- **wolfSSL**: 5.8.0 Commercial FIPS v5.2.3
+- **wolfSSL**: 5.9.1 Commercial FIPS v5.2.3
 - **Base Image**: Root.io OpenJDK 19 (Debian Bookworm Slim)
 - **wolfcrypt-jni**: Master branch (GitHub)
 - **wolfssljni**: Master branch (GitHub)

--- a/java/wolfssl-openjdk-fips-root/src/providers/FilteredSun.java
+++ b/java/wolfssl-openjdk-fips-root/src/providers/FilteredSun.java
@@ -35,7 +35,6 @@ import java.util.Set;
  * non-cryptographic services from the original SUN provider.
  *
  * It retains only the services:
- *     - CertPathBuilder.PKIX
  *     - CertStore.Collection
  *     - CertStore.com.sun.security.IndexedCollection
  *     - CertificateFactory.X.509
@@ -98,11 +97,6 @@ public class FilteredSun extends Provider {
         String algo = service.getAlgorithm();
 
         switch (type) {
-            case "CertPathBuilder":
-                if (algo.equals("PKIX")) {
-                    return true;
-                }
-                break;
             case "CertStore":
                 if (algo.equals("Collection") ||
                     algo.equals("com.sun.security.IndexedCollection")) {

--- a/java/wolfssl-openjdk-fips-root/src/providers/FilteredSunEC.java
+++ b/java/wolfssl-openjdk-fips-root/src/providers/FilteredSunEC.java
@@ -35,11 +35,9 @@ import java.util.Set;
  * FilteredSunEC is a custom security provider that filters out
  * non-cryptographic services from the original SunEC provider.
  *
- * It retains only the services related to EC (Elliptic Curve)
- * AlgorithmParameters and KeyFactory:
+ * It retains only:
  *
  *     - AlgorithmParameters.EC
- *     - KeyFactory.EC.
  */
 public class FilteredSunEC extends Provider {
 
@@ -99,11 +97,6 @@ public class FilteredSunEC extends Provider {
 
         switch (type) {
             case "AlgorithmParameters":
-                if (algo.equals("EC")) {
-                    return true;
-                }
-                break;
-            case "KeyFactory":
                 if (algo.equals("EC")) {
                     return true;
                 }

--- a/java/wolfssl-openjdk-fips-root/src/providers/FilteredSunRsaSign.java
+++ b/java/wolfssl-openjdk-fips-root/src/providers/FilteredSunRsaSign.java
@@ -35,8 +35,7 @@ import java.util.Set;
  * FilteredSunRsaSign is a custom security provider that filters out
  * non-cryptographic services from the original SunRsaSign provider.
  *
- * It retains only the services related to RSA (RSA and RSASSA-PSS) KeyFactory:
- *     - KeyFactory.RSA
+ * It retains only:
  *     - KeyFactory.RSASSA-PSS
  */
 public class FilteredSunRsaSign extends Provider {
@@ -97,7 +96,7 @@ public class FilteredSunRsaSign extends Provider {
 
         switch (type) {
             case "KeyFactory":
-                if (algo.equals("RSA") || algo.equals("RSASSA-PSS")) {
+                if (algo.equals("RSASSA-PSS")) {
                     return true;
                 }
                 break;


### PR DESCRIPTION
This PR updates the `wolfssl-openjdk-fips-root` container:

- Updates to use the most current `wolfssl-5.9.1-commercial-fips-v5.2.3.7z`
- Updates the custom filtered security providers to remove the following, now that wolfJCE/JSSE implements these.
  - KeyFactory(EC)
  - KeyFactory(RSA)
  - CertPathBuilder(PKIX)
- Added SHA-256 sum check against native wolfssl .7z