### PR TITLE
Java: add wolfSSL FIPS Ready build option to Java container build

### DIFF
--- a/java/wolfssl-openjdk-fips-root/Dockerfile
+++ b/java/wolfssl-openjdk-fips-root/Dockerfile
@@ -19,6 +19,13 @@ ARG WOLFCRYPT_JNI_BRANCH="master"
 ARG WOLFSSL_JNI_REPO="https://github.com/wolfSSL/wolfssljni.git"
 ARG WOLFSSL_JNI_BRANCH="master"
 
+# wolfSSL FIPS variant used for the native wolfSSL build.
+# Values select the wolfssl-source-* stage that feeds the wolfssl-builder
+# stage below:
+#   v5.2.3 (default) - password-protected commercial FIPS bundle
+#   ready            - public GPLv3 wolfSSL "FIPS Ready" bundle
+ARG FIPS_VARIANT="v5.2.3"
+
 # ------------------------------------------------------------------------------
 # Stage 1: Build Environment
 # ------------------------------------------------------------------------------
@@ -57,11 +64,15 @@ ENV CLASSPATH=$JUNIT_HOME/junit-4.13.2.jar:$JUNIT_HOME/hamcrest-core-1.3.jar
 # ------------------------------------------------------------------------------
 # Stage 2: Build Native wolfSSL FIPS 140-3 library
 # ------------------------------------------------------------------------------
-FROM builder AS wolfssl-builder
+# Two alternative source stages are defined below. The FIPS_VARIANT build arg
+# selects which one feeds the wolfssl-builder stage, and is passed directly
+# to ./configure --enable-fips=<variant>.
 
-# Download and extract wolfSSL commercial FIPS source using BuildKit secret.
+# Commercial FIPS v5.2.3 bundle (default). Download and extract wolfSSL
+# commercial FIPS source using BuildKit secret for the bundle password.
 # This bundle name can change depending on wolfCrypt FIPS OE
-RUN --mount=type=secret,id=wolfssl_pw \
+FROM builder AS wolfssl-source-v5.2.3
+RUN --mount=type=secret,id=wolfssl_pw,required=true \
     PW="$(cat /run/secrets/wolfssl_pw)" \
     && curl -fLso /tmp/wolfssl-commercial.7z "https://www.wolfssl.com/comm/wolfssl/wolfssl-5.9.1-commercial-fips-v5.2.3.7z" \
     && echo "13280504dbfea0cb891404ef9ad4f2ee3ab02e0a327c80f93bc1f546224ef8db  /tmp/wolfssl-commercial.7z" | sha256sum -c - \
@@ -70,7 +81,23 @@ RUN --mount=type=secret,id=wolfssl_pw \
     && ls -la /build/ \
     && find /build -maxdepth 1 -type d -name "*wolfssl*" -exec mv {} /build/wolfssl \;
 
-# Build wolfSSL v5.2.3 (cert 4718) with JNI support enabled.
+# wolfSSL "FIPS Ready" bundle (GPLv3). Publicly downloadable, no password
+# required. FIPS Ready contains the wolfCrypt FIPS module code but is NOT a
+# FIPS validated module.
+FROM builder AS wolfssl-source-ready
+RUN curl -fLso /tmp/wolfssl-fips-ready.zip "https://www.wolfssl.com/wolfssl-5.9.1-gplv3-fips-ready.zip" \
+    && echo "c7a12081ead6cd67778e032602451e9efd13716cd0531fe2bc16ca796cd0a0e6  /tmp/wolfssl-fips-ready.zip" | sha256sum -c - \
+    && 7z x /tmp/wolfssl-fips-ready.zip -o/build \
+    && rm -f /tmp/wolfssl-fips-ready.zip \
+    && ls -la /build/ \
+    && find /build -maxdepth 1 -type d -name "*wolfssl*" -exec mv {} /build/wolfssl \;
+
+FROM wolfssl-source-${FIPS_VARIANT} AS wolfssl-builder
+ARG FIPS_VARIANT
+
+# Build wolfSSL with JNI support enabled, in the FIPS mode selected by
+# FIPS_VARIANT (v5.2.3 for the commercial bundle / cert 4718, ready for the
+# FIPS Ready bundle).
 # Running ./fips-hash.sh sets the in-core integrity check hash, after which
 # make needs to be run again to incorporate the updated hash value.
 # We run the wolfCrypt test app to verify native crypto is working after
@@ -78,7 +105,7 @@ RUN --mount=type=secret,id=wolfssl_pw \
 # Disabling MD5 since is not a FIPS validated algorithm in cert 4718.
 WORKDIR /build/wolfssl
 RUN ./configure \
-        --enable-fips=v5 \
+        --enable-fips=${FIPS_VARIANT} \
         --enable-jni \
         --disable-md5 \
         --prefix=/usr/local \
@@ -231,6 +258,15 @@ RUN mkdir -p /build/classes \
 # Stage 6: Runtime Image
 # ------------------------------------------------------------------------------
 FROM rootpublic/openjdk:19-jdk-bookworm-slim
+
+# Record which wolfSSL FIPS bundle variant this image was built from.
+# Images built with FIPS_VARIANT=ready are NOT FIPS validated.
+# WOLFSSL_FIPS_VARIANT is also used by FipsInitCheck at container startup to
+# adjust algorithm availability expectations (e.g. SHA1withECDSA is not
+# available from the newer FIPS module used in FIPS Ready builds).
+ARG FIPS_VARIANT
+LABEL com.wolfssl.fips.variant="${FIPS_VARIANT}"
+ENV WOLFSSL_FIPS_VARIANT=${FIPS_VARIANT}
 
 # No additional runtime dependencies needed
 

--- a/java/wolfssl-openjdk-fips-root/README.md
+++ b/java/wolfssl-openjdk-fips-root/README.md
@@ -141,10 +141,12 @@ properly:
 ### Prerequisites
 
 - Docker installed and running
-- wolfSSL commercial FIPS package password (required for build)
+- wolfSSL commercial FIPS package password (required for default build)
     + Commercial wolfCrypt packages are provided directly via wolfSSL
     + This package has been tested with Certificate #4718 / FIPS 140-3 (v5.2.3)
     + Password must be supplied at image build time to extract .7z
+    + Not required when building with `--fips=ready` (see
+      [FIPS Ready Builds](#fips-ready-builds))
 
 ### Build Options
 
@@ -164,6 +166,10 @@ repositories to pull in the latest JCE/JSSE provider code.
 - `--wolfssl-jni PATH` - Use local wolfssljni directory
 
 **Build Configuration:**
+- `--fips VARIANT` (or `--fips=VARIANT`) - wolfSSL FIPS variant to build,
+  mirroring wolfSSL's `--enable-fips` configure values: `v5.2.3` (commercial
+  FIPS bundle, default) or `ready` (public GPLv3 wolfSSL FIPS Ready bundle,
+  no password required)
 - `--no-cache` - Disable Docker build cache
 - `--cache-from IMAGE` - Use cache from existing image
 - `-v, --verbose` - Enable verbose build output and debug logging
@@ -185,6 +191,42 @@ repositories to pull in the latest JCE/JSSE provider code.
 
 # Using local development directories
 ./build.sh -p your_wolfssl_password --wolfcrypt-jni ../wolfcrypt-jni-dev --wolfssl-jni ../wolfssljni-dev
+
+# Evaluation build using the GPLv3 FIPS Ready bundle (no password)
+./build.sh --fips=ready
+```
+
+### FIPS Ready Builds
+
+By default this container builds against the commercial wolfSSL FIPS bundle,
+which is password-protected and distributed directly by wolfSSL to customers.
+For users who want to evaluate the container without a commercial bundle, the
+`--fips=ready` option builds against the publicly downloadable, GPLv3-licensed
+[wolfSSL FIPS Ready](https://www.wolfssl.com/license/fips/) bundle instead:
+
+```bash
+./build.sh --fips=ready
+```
+
+FIPS Ready builds compile the same wolfCrypt FIPS module code and run it in
+FIPS Ready mode (`./configure --enable-fips=ready`), including the FIPS
+in-core integrity check and power-on self tests. However, **FIPS Ready is NOT
+a FIPS validated module** and must not be used where validated cryptography
+is required. For production/compliance use, build with the commercial FIPS
+bundle (contact fips@wolfssl.com).
+
+Algorithm availability may also differ slightly, since FIPS Ready tracks a
+newer wolfCrypt FIPS module than Certificate #4718. For example,
+`SHA1withECDSA` is not available in FIPS Ready builds (FIPS 186-5 disallows
+SHA-1 with ECDSA). The container startup checks (`FipsInitCheck`) adjust
+their expectations automatically based on the `WOLFSSL_FIPS_VARIANT`
+environment variable baked into the image.
+
+Images record the bundle variant they were built from in the
+`com.wolfssl.fips.variant` label (`v5.2.3` or `ready`):
+
+```bash
+docker inspect --format '{{index .Config.Labels "com.wolfssl.fips.variant"}}' wolfssl-openjdk-fips-root:latest
 ```
 
 ### Run the Container
@@ -214,6 +256,7 @@ docker run -v /path/to/your/app:/app \
 | `JAVA_OPTS` | JVM configuration options | `-Xmx512m` |
 | `JAVA_TOOL_OPTIONS` | JVM module access flags for filtered providers | See Dockerfile |
 | `CLASSPATH` | Application classpath including provider JARs (for ServiceLoader) | `/usr/share/java/*.jar` |
+| `WOLFSSL_FIPS_VARIANT` | wolfSSL FIPS bundle variant the image was built from (set at build time, used by startup FIPS checks) | `v5.2.3` or `ready` |
 | `WOLFJCE_DEBUG` | Enable wolfJCE debug logging | `false` |
 | `WOLFJSSE_DEBUG` | Enable wolfJSSE debug logging | `false` |
 | `WOLFJSSE_ENGINE_DEBUG` | Enable wolfJSSE SSLEngine debug logging | `false` |
@@ -526,11 +569,12 @@ builds of this container use wolfSSL 5.9.1 and are not affected.
 
 ## Version Information
 
-- **wolfSSL**: 5.9.1 Commercial FIPS v5.2.3
+- **wolfSSL**: 5.9.1 Commercial FIPS v5.2.3 (default),
+  or 5.9.1 GPLv3 FIPS Ready (with `--fips=ready`, not FIPS validated)
 - **Base Image**: Root.io OpenJDK 19 (Debian Bookworm Slim)
 - **wolfcrypt-jni**: Master branch (GitHub)
 - **wolfssljni**: Master branch (GitHub)
-- **FIPS Certificate**: #4718
+- **FIPS Certificate**: #4718 (commercial FIPS builds)
 
 ## Documentation
 

--- a/java/wolfssl-openjdk-fips-root/build.sh
+++ b/java/wolfssl-openjdk-fips-root/build.sh
@@ -7,6 +7,7 @@ set -e
 IMAGE_NAME="wolfssl-openjdk-fips-root"
 IMAGE_TAG="latest"
 WOLFSSL_PASSWORD=""
+FIPS_VARIANT="v5.2.3"
 BUILD_ARGS=""
 export DOCKER_BUILDKIT=1
 : "${BUILDKIT_PROGRESS:=auto}"
@@ -30,7 +31,15 @@ usage() {
     echo "Usage: $0 [OPTIONS]"
     echo ""
     echo "Options:"
-    echo "  -p, --password PASSWORD   wolfSSL commercial FIPS package password (required)"
+    echo "  -p, --password PASSWORD   wolfSSL commercial FIPS package password"
+    echo "                            (required unless --fips=ready is used)"
+    echo "  --fips VARIANT            wolfSSL FIPS variant to build (--fips=VARIANT also"
+    echo "                            accepted), mirrors wolfSSL's --enable-fips values:"
+    echo "                              v5.2.3 - commercial FIPS bundle (default),"
+    echo "                                       requires -p/--password"
+    echo "                              ready  - public GPLv3 wolfSSL FIPS Ready bundle,"
+    echo "                                       no password required. For evaluation use,"
+    echo "                                       NOT FIPS validated"
     echo "  -n, --name NAME           Docker image name (default: wolfssl-openjdk-fips-root)"
     echo "  -t, --tag TAG             Docker image tag (default: latest)"
     echo "  --no-cache                Disable Docker build cache (cache enabled by default)"
@@ -46,6 +55,7 @@ usage() {
     echo ""
     echo "Examples:"
     echo "  $0 -p your_password                        # Basic build (with cache)"
+    echo "  $0 --fips=ready                            # Evaluation/CI build with GPLv3 FIPS Ready bundle"
     echo "  $0 -p your_password --no-cache             # Build without cache"
     echo "  $0 -p your_password --cache-from myimg     # Use cache from existing image"
     echo "  $0 -p your_password -v                     # Verbose build with wolfSSL debug logging"
@@ -61,6 +71,14 @@ while [[ $# -gt 0 ]]; do
         -p|--password)
             WOLFSSL_PASSWORD="$2"
             shift 2
+            ;;
+        --fips)
+            FIPS_VARIANT="$2"
+            shift 2
+            ;;
+        --fips=*)
+            FIPS_VARIANT="${1#*=}"
+            shift
             ;;
         -n|--name)
             IMAGE_NAME="$2"
@@ -121,11 +139,33 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Validate required arguments
-if [ -z "$WOLFSSL_PASSWORD" ]; then
-    echo -e "${RED}Error: wolfSSL password is required${NC}"
-    echo "Use -p or --password to specify the password"
-    exit 1
+case "$FIPS_VARIANT" in
+    v5.2.3|ready)
+        ;;
+    *)
+        echo -e "${RED}Error: Unsupported FIPS variant '$FIPS_VARIANT'${NC}"
+        echo "Supported values: v5.2.3 (commercial, default), ready (GPLv3 FIPS Ready)"
+        exit 1
+        ;;
+esac
+
+if [ "$FIPS_VARIANT" = "ready" ]; then
+    if [ -n "$WOLFSSL_PASSWORD" ]; then
+        echo -e "${RED}Error: --fips=ready uses the public GPLv3 FIPS Ready bundle and does not take a password${NC}"
+        echo "Remove -p/--password, or use --fips=v5.2.3 to build the commercial FIPS package"
+        exit 1
+    fi
+else
+    if [ -z "$WOLFSSL_PASSWORD" ]; then
+        echo -e "${RED}Error: wolfSSL password is required${NC}"
+        echo "Use -p or --password to specify the password,"
+        echo "or use --fips=ready to build with the public GPLv3 FIPS Ready bundle"
+        exit 1
+    fi
 fi
+
+# Pass selected wolfSSL FIPS bundle variant to Docker build
+BUILD_ARGS="$BUILD_ARGS --build-arg FIPS_VARIANT=$FIPS_VARIANT"
 
 # Validate local directories if specified
 if [ -n "$WOLFCRYPT_JNI_LOCAL" ]; then
@@ -179,6 +219,10 @@ FULL_IMAGE_NAME="${IMAGE_NAME}:${IMAGE_TAG}"
 
 echo -e "${GREEN}Building FIPS-compliant wolfSSL OpenJDK container...${NC}"
 echo -e "${YELLOW}Image name: $FULL_IMAGE_NAME${NC}"
+echo -e "${YELLOW}wolfSSL FIPS bundle: $FIPS_VARIANT${NC}"
+if [ "$FIPS_VARIANT" = "ready" ]; then
+    echo -e "${YELLOW}NOTE: FIPS Ready builds are for evaluation/CI and are NOT FIPS validated${NC}"
+fi
 echo ""
 
 # Prepare build context with local directories if specified
@@ -220,8 +264,10 @@ fi
 echo -e "${GREEN}Starting Docker build...${NC}"
 export DOCKER_BUILDKIT=$DOCKER_BUILDKIT
 
-# Prepare BuildKit secret
-if [[ -n "${WOLFSSL_PASSWORD:-}" ]]; then
+# Prepare BuildKit secret (commercial bundle only, FIPS Ready needs no password)
+if [ "$FIPS_VARIANT" = "ready" ]; then
+    SECRET_FLAG=()
+elif [[ -n "${WOLFSSL_PASSWORD:-}" ]]; then
     export WOLFSSL_PASSWORD
     SECRET_FLAG=( --secret id=wolfssl_pw,env=WOLFSSL_PASSWORD )
 else
@@ -278,6 +324,7 @@ if [ $? -eq 0 ]; then
     echo ""
     echo -e "${GREEN}Build Summary:${NC}"
     echo -e "${GREEN}  Image: $FULL_IMAGE_NAME${NC}"
+    echo -e "${GREEN}  wolfSSL FIPS bundle: $FIPS_VARIANT${NC}"
     echo -e "${GREEN}  Status: Ready for use${NC}"
     echo ""
     echo -e "${YELLOW}To run the container:${NC}"

--- a/java/wolfssl-openjdk-fips-root/src/main/FipsInitCheck.java
+++ b/java/wolfssl-openjdk-fips-root/src/main/FipsInitCheck.java
@@ -61,6 +61,16 @@ public class FipsInitCheck {
             System.out.println("\nSecurity Manager: " +
                 (sm == null ? "None" : sm.getClass().getName()));
 
+            /* wolfSSL FIPS bundle variant this image was built from,
+             * set as WOLFSSL_FIPS_VARIANT in the Dockerfile runtime stage.
+             * Informational only here; algorithm availability checks below
+             * adjust expectations for FIPS Ready ("ready") builds. */
+            String fipsVariant = System.getenv("WOLFSSL_FIPS_VARIANT");
+            System.out.println("wolfSSL FIPS bundle variant: " +
+                (fipsVariant == null ? "unknown" : fipsVariant) +
+                ("ready".equals(fipsVariant) ?
+                 " (FIPS Ready, NOT FIPS validated)" : ""));
+
             /* List all currently loaded providers, informational */
             listAllRegisteredSecurityProviders();
 
@@ -449,14 +459,17 @@ public class FipsInitCheck {
             "DESede/ECB/NoPadding"
         };
 
-        /* Signature - FIPS and non-FIPS validated algorithms */
+        /* Signature - FIPS and non-FIPS validated algorithms.
+         * SHA1withECDSA is available from the commercial FIPS v5.2.3 module
+         * (cert 4718). Newer wolfCrypt FIPS modules, as used by FIPS Ready
+         * builds, disallow SHA-1 with ECDSA (FIPS 186-5), so wolfJCE does
+         * not register it and it must not be available there. */
         String[] fipsApprovedSignatures = {
             "SHA1withRSA",
             "SHA224withRSA",
             "SHA256withRSA",
             "SHA384withRSA",
             "SHA512withRSA",
-            "SHA1withECDSA",
             "SHA224withECDSA",
             "SHA256withECDSA",
             "SHA384withECDSA",
@@ -476,6 +489,17 @@ public class FipsInitCheck {
             "SHA512withRSA/PSS"
         };
         String[] nonFipsSignatures = {};
+
+        boolean fipsReadyBuild =
+            "ready".equals(System.getenv("WOLFSSL_FIPS_VARIANT"));
+        if (fipsReadyBuild) {
+            nonFipsSignatures = new String[] { "SHA1withECDSA" };
+        } else {
+            fipsApprovedSignatures = Arrays.copyOf(fipsApprovedSignatures,
+                fipsApprovedSignatures.length + 1);
+            fipsApprovedSignatures[fipsApprovedSignatures.length - 1] =
+                "SHA1withECDSA";
+        }
 
         /* SSLContext protocols */
         String[] sslContexts = {

--- a/java/wolfssl-openjdk-fips-root/test-images/basic-test-image/Dockerfile
+++ b/java/wolfssl-openjdk-fips-root/test-images/basic-test-image/Dockerfile
@@ -2,7 +2,10 @@
 # Extends the wolfssl-openjdk-fips-root base image to provide basic testing
 # of JCA cryptographic operations and TLS functionality
 
-FROM wolfssl-openjdk-fips-root:latest
+# Base image is configurable so the test image can be built against any tag
+# or variant of the base image (build.sh passes this via -b/--base)
+ARG BASE_IMAGE=wolfssl-openjdk-fips-root:latest
+FROM ${BASE_IMAGE}
 
 LABEL maintainer="wolfSSL Inc. <support@wolfssl.com>"
 LABEL description="FIPS-compliant wolfSSL Java test application demonstrating JCA and TLS usage"

--- a/java/wolfssl-openjdk-fips-root/test-images/basic-test-image/src/main/CryptoTestSuite.java
+++ b/java/wolfssl-openjdk-fips-root/test-images/basic-test-image/src/main/CryptoTestSuite.java
@@ -554,10 +554,31 @@ public class CryptoTestSuite {
         KeyPair keyPair = keyPairGen.generateKeyPair();
 
         String[] algorithms = {
-            "SHA1withECDSA", "SHA224withECDSA", "SHA256withECDSA",
+            "SHA224withECDSA", "SHA256withECDSA",
             "SHA384withECDSA", "SHA512withECDSA", "SHA3-224withECDSA",
             "SHA3-256withECDSA", "SHA3-384withECDSA", "SHA3-512withECDSA"
         };
+
+        /* SHA1withECDSA is available from the commercial FIPS v5.2.3 module
+         * (cert 4718). Newer wolfCrypt FIPS modules, as used by FIPS Ready
+         * builds, disallow SHA-1 with ECDSA (FIPS 186-5), so wolfJCE does
+         * not register it. The base image records its bundle variant in
+         * the WOLFSSL_FIPS_VARIANT environment variable. */
+        boolean fipsReadyBuild =
+            "ready".equals(System.getenv("WOLFSSL_FIPS_VARIANT"));
+        if (fipsReadyBuild) {
+            try {
+                Signature.getInstance("SHA1withECDSA");
+                throw new SecurityException("SHA1withECDSA should not be " +
+                    "available in FIPS Ready builds");
+            } catch (NoSuchAlgorithmException e) {
+                System.out.println("   SHA1withECDSA: UNAVAILABLE " +
+                    "(correctly not available in FIPS Ready builds)");
+            }
+        } else {
+            algorithms = Arrays.copyOf(algorithms, algorithms.length + 1);
+            algorithms[algorithms.length - 1] = "SHA1withECDSA";
+        }
 
         for (String algorithm : algorithms) {
             Signature signature = Signature.getInstance(algorithm);


### PR DESCRIPTION
This PR adds a FIPS Ready (`--fips=ready`) option to `build.sh`, allowing for easier evaluation of the Java secure container without needing a commercial license / password for commercial archive.

  - `v5.2.3` (default) - commercial FIPS bundle, requires `-p/--password`
  - `ready` - public GPLv3 FIPS Ready bundle, no password required. Intended for evaluation, NOT FIPS validated.

```
./build.sh --fips=ready
```

### Changes

  - **build.sh**: `--fips=<variant>` option with validation; password only required for commercial builds; BuildKit secret only passed when needed
  - **Dockerfile**: `FIPS_VARIANT` build arg selects between commercial and FIPS Ready source stages; variant passed directly to `./configure --enable-fips=<variant>` (commercial now uses `v5.2.3` instead of `v5`); FIPS Ready zip pinned by SHA-256; images record their variant in the `com.wolfssl.fips.variant` label and `WOLFSSL_FIPS_VARIANT` env var
  - **FipsInitCheck.java / CryptoTestSuite.java**: startup and test checks are now variant-aware — `SHA1withECDSA` is expected to be unavailable in FIPS Ready builds (FIPS 186-5 disallows SHA-1 with ECDSA)
  - **test-images/basic-test-image**: fix `-b/--base` option, which was silently ignored (`BASE_IMAGE` build arg was never declared in Dockerfile)

  ### Testing

  - `./build.sh --fips=ready`: full build, all wolfcrypt-jni/wolfssljni JUnit suites and container startup FIPS checks pass (70/70)
  - basic-test-image built against FIPS Ready base: all JCA/TLS tests pass
  - Commercial path: argument validation regression-tested